### PR TITLE
Resolves issue #10

### DIFF
--- a/src/vmod_vsthrottle.c
+++ b/src/vmod_vsthrottle.c
@@ -46,6 +46,10 @@
 
 #include "vcc_if.h"
 
+#ifdef __MACH__
+#include <mach/clock.h>
+#include <mach/mach.h>
+#endif
 
 /* Represents a token bucket for a specific key. */
 struct tbucket {
@@ -136,6 +140,28 @@ calc_tokens(struct tbucket *b, double now)
 		b->tokens = b->capacity;
 	/* VSL(SLT_VCL_Log, 0, "tokens: %ld", b->tokens); */
 }
+
+/* OS X does not have clock_gettime */
+#ifdef __MACH__
+#define CLOCK_MONOTONIC SYSTEM_CLOCK
+
+int
+clock_gettime(clock_id_t clk_id, struct timespec *ts)
+{
+	kern_return_t retval = KERN_SUCCESS;
+	clock_serv_t cclock;
+	mach_timespec_t mts;
+
+	host_get_clock_service(mach_host_self(), clk_id, &cclock);
+	retval = clock_get_time(cclock, &mts);
+	mach_port_deallocate(mach_task_self(), cclock);
+	ts->tv_sec = mts.tv_sec;
+	ts->tv_nsec = mts.tv_nsec;
+
+	return retval;
+}
+
+#endif
 
 static double
 get_ts_mono(void)


### PR DESCRIPTION
This is my absolute n00b attempt to create a clock_gettime equivalent for OSX
without messing about with other platforms. I'm probably doing it wrong?

I've been able to compile and run this VMOD on OSX 10.10 under varnish
4.1.1 as well as ubuntu precise lts 12.4.5
